### PR TITLE
Supporting grouped environments

### DIFF
--- a/client/components/result-table.js
+++ b/client/components/result-table.js
@@ -4,38 +4,54 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 import ResultCell from './result-cell';
 
-const ResultTable = (props) => (
-  <table width="100%" className="results-table">
-    <thead>
-      <tr>
-        {props.headerElements.map((elem, index) => React.cloneElement(elem, {key: `header-${index}`}))}
-        <td width={`${props.browserColumnWidth}%`} style={{textAlign: "center"}} className="browser">
-          <i className="fa fa-internet-explorer"></i>
-        </td>
-        <td width={`${props.browserColumnWidth}%`} style={{textAlign: "center"}} className="browser">
-          <i className="fa fa-chrome"></i>
-        </td>
-        <td width={`${props.browserColumnWidth}%`} style={{textAlign: "center"}} className="browser">
-          <i className="fa fa-safari"></i>
-        </td>
-        <td width={`${props.browserColumnWidth}%`} style={{textAlign: "center"}} className="browser">
-          <i className="fa fa-apple"></i>
-        </td>
-      </tr>
-    </thead>
-    <ReactCSSTransitionGroup component="tbody" transitionName="example" transitionEnterTimeout={500} transitionLeaveTimeout={300}>
-      {props.results.map((result, index) => (
-        <tr key={props.indexGenerator(result)}>
-          {props.rowElements(result).map((elem, sindex) => React.cloneElement(elem, {key: `extra-columns-${sindex}-${index}`}))}
-          <ResultCell result={result.environments.ie} />
-          <ResultCell result={result.environments.chrome} />
-          <ResultCell result={result.environments.safari} />
-          <ResultCell result={result.environments.ios} />
+import { buildColumns } from '../utilities/environments';
+
+const ResultTable = (props) => {
+  console.log(props.project.environments);
+  const {columns, colWidth, sections} = buildColumns(props.project.environments || [
+    "ie",
+    "chrome",
+    "safari",
+    "ios"
+  ]);
+  const headerElements = props.headerElements.map((elem, index) => React.cloneElement(elem, {key: `header-${index}`}));
+
+  return (
+    <table width="100%" className="results-table">
+      <thead>
+        <tr>
+          {headerElements.map((elem, index) => (
+            <td key={`spacer-${index}`} />
+          ))}
+          {sections.map((sect, index) => (
+            <td key={`section-${index}`} colSpan={sect.cols} style={{textAlign: 'center'}} className="browser">
+              <i className={`fa ${sect.icon}`} />
+            </td>
+          ))}
         </tr>
-      ))}
-    </ReactCSSTransitionGroup>
-  </table>
-);
+        <tr>
+          {headerElements}
+          {columns.map((col, index) => (
+            <td width={`${colWidth}%`} style={{textAlign: 'center'}} key={`title-${index}`}>
+              {col.name}
+            </td>
+          ))}
+        </tr>
+      </thead>
+      <ReactCSSTransitionGroup component="tbody" transitionName="example" transitionEnterTimeout={500} transitionLeaveTimeout={300}>
+        {props.results.map((result, index) => (
+          <tr key={props.indexGenerator(result)}>
+            {props.rowElements(result).map((elem, sindex) => React.cloneElement(elem, {key: `extra-columns-${sindex}-${index}`}))}
+            {columns.map((col, cindex) => (
+              <ResultCell result={result.environments[col.key]} key={`${index}-${cindex}`} />
+            ))}
+          </tr>
+        ))}
+      </ReactCSSTransitionGroup>
+    </table>
+  );
+}
+
 
 ResultTable.defaultProps = {
   browserColumnWidth: 15,

--- a/client/pages/result-detail.js
+++ b/client/pages/result-detail.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import ResultTable from '../components/result-table';
 
+import { Projects } from '../../imports/api/projects';
 import { TestRun } from '../../imports/api/test-run';
 import { TestResult } from '../../imports/api/test-result';
 
@@ -16,6 +17,7 @@ export class ResultDetail extends React.Component {
         <h2>Test History</h2>
         <ResultTable
           results={this.props.history}
+          project={this.props.project}
           headerElements={[
             <td width="20%">Phase</td>,
             <td width="25%">Run</td>,
@@ -40,7 +42,9 @@ export const ResultDetailContainer = createContainer(({ run, result }) => {
   const runObj = TestRun.findOne({_id: run});
   const resultObj = TestResult.findOne({_id: result});
   let history = [];
+  let project = {};
   if (runObj && resultObj) {
+    project = Projects.findOne(resultObj.project);
     history = TestResult.find({
       test: resultObj.test,
       project: resultObj.project
@@ -49,6 +53,7 @@ export const ResultDetailContainer = createContainer(({ run, result }) => {
   return {
     run: runObj || {},
     result: resultObj || {},
+    project,
     history
   };
 }, ResultDetail);

--- a/client/pages/run-report.js
+++ b/client/pages/run-report.js
@@ -10,6 +10,7 @@ import ResultCell from '../components/result-cell';
 import { Projects } from '../../imports/api/projects';
 import { TestRun } from '../../imports/api/test-run';
 import { TestResult } from '../../imports/api/test-result';
+import { buildColumns } from '../utilities/environments';
 
 const _time = (val) => {
   if (val < 1000) {
@@ -52,6 +53,13 @@ export class RunReport extends React.Component {
     );
   }
   render() {
+    const {columns, colWidth, sections} = buildColumns(this.props.project.environments || [
+      "ie",
+      "chrome",
+      "safari",
+      "ios"
+    ]);
+
     const sortedResults = this.props.results.sort((a, b) => {
       let score_a = 0;
       for (var k in a.environments) {
@@ -71,6 +79,7 @@ export class RunReport extends React.Component {
         return 0;
       }
     });
+
     return (
       <div>
         <h1><ProjectLink project={this.props.run.project_name}/> |&nbsp;
@@ -81,21 +90,22 @@ export class RunReport extends React.Component {
         <table width="100%" className="results-table">
           <thead>
             <tr>
-              <td width="40%">
+              <td width="40%" />
+              {sections.map((sect, index) => (
+                <td key={`section-${index}`} colSpan={sect.cols} style={{textAlign: 'center'}} className="browser">
+                  <i className={`fa ${sect.icon}`} />
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <td>
                 Test name
               </td>
-              <td width="15%" style={{textAlign: 'center'}} className="browser">
-                <i className="fa fa-internet-explorer"></i>
-              </td>
-              <td width="15%" style={{textAlign: 'center'}} className="browser">
-                <i className="fa fa-chrome"></i>
-              </td>
-              <td width="15%" style={{textAlign: 'center'}} className="browser">
-                <i className="fa fa-safari"></i>
-              </td>
-              <td width="15%" style={{textAlign: 'center'}} className="browser">
-                <i className="fa fa-apple"></i>
-              </td>
+              {columns.map((col, index) => (
+                <td width={`${colWidth}%`} style={{textAlign: 'center'}} key={`title-${index}`}>
+                  {col.name}
+                </td>
+              ))}
             </tr>
           </thead>
           <ReactCSSTransitionGroup component="tbody" transitionName="example" transitionEnterTimeout={500} transitionLeaveTimeout={300}>
@@ -104,10 +114,9 @@ export class RunReport extends React.Component {
                 <td>
                   <a href={`/run/${this.props.run._id}/${result._id}`}>{result.test}</a>
                 </td>
-                <ResultCell result={result.environments.ie} />
-                <ResultCell result={result.environments.chrome} />
-                <ResultCell result={result.environments.safari} />
-                <ResultCell result={result.environments.ios} />
+                {columns.map((col, cindex) => (
+                  <ResultCell result={result.environments[col.key]} key={`${index}-${cindex}`} />
+                ))}
               </tr>
             ))}
           </ReactCSSTransitionGroup>

--- a/client/utilities/environments.js
+++ b/client/utilities/environments.js
@@ -12,7 +12,7 @@ export const buildColumns = (envs) => {
     if (info[0] === "safari") {
       icon = "fa-safari";
     }
-    if (info[0] === "ios") {
+    if (info[0] === "iOS") {
       icon = "fa-apple";
     }
 

--- a/client/utilities/environments.js
+++ b/client/utilities/environments.js
@@ -1,0 +1,56 @@
+export const buildColumns = (envs) => {
+  const environments = envs.sort();
+
+  const colWidth = 60.0 / environments.length;
+  const columns = [];
+  for (env of environments) {
+    const info = env.split(/\|/);
+    let icon = "fa-internet-explorer";
+    if (info[0] === "chrome") {
+      icon = "fa-chrome";
+    }
+    if (info[0] === "safari") {
+      icon = "fa-safari";
+    }
+    if (info[0] === "ios") {
+      icon = "fa-apple";
+    }
+
+    const version = info.length > 1 ? info[1] : "";
+    const width = info.length > 2 ? info[2] : "";
+
+    let name = version;
+    if (width && width.length > 0) {
+      if (name.length > 0) {
+        name += ':'
+      }
+      name += `${width}`;
+    }
+
+    columns.push({
+      icon,
+      version,
+      width,
+      name,
+      section: info[0],
+      key: env
+    });
+  }
+
+  let curSection = null;
+  const sections = [];
+  for (var col of columns) {
+    if (col.section !== curSection) {
+      sections.push({
+        section: col.section,
+        icon: col.icon,
+        cols: 1
+      });
+      curSection = col.section;
+    } else {
+      sections[sections.length - 1].cols += 1;
+    }
+  }
+
+  return {columns, colWidth, sections};
+}


### PR DESCRIPTION
Environments can now support version and dimension information. Example: `IE|9|medium` is Internet Explorer 9 in medium size.